### PR TITLE
fix typo in long-spec.json.sample

### DIFF
--- a/long-spec.json.sample
+++ b/long-spec.json.sample
@@ -22,5 +22,5 @@
  "noshap": false,
  "nsamples": 100,
  "l1_reg": "aic",
- "metric": ["roc_auc_score", "accuracy_score"]
+ "metrics": ["roc_auc_score", "accuracy_score"]
  }


### PR DESCRIPTION
Change "metric" to "metrics"