### PR TITLE
added SHAP output in gen_report, changed noshap to gen_shap, explained output structure in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+cache-wf
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -72,12 +72,10 @@ will want to generate `x_indices` programmatically.
 - *test_size*: Fraction of data to use for test set in each iteration
 - *clf_info*: List of scikit-learn classifiers to use.
 - *permute*: List of booleans to indicate whether to generate a null model or not
-- *gen_shap*: Boolean indicating whether shap values are evaluated
+- *gen_shap*: Boolean indicating whether shap values are generated
 - *nsamples*: Number of samples to use for shap estimation
 - *l1_reg*: Type of regularizer to use for shap estimation
-- *plot_shap*: Boolean indicating whether shap values are plotted (csv will be created if gen_shap is true)
-- *plot_top_n_shap*: Number of top shap values to plot ranked by mean across splits
-- *confusion_matrix*: Boolean indicating whether to also compute SHAP values for TP, TN, FP, and FN
+- *plot_top_n_shap*: Number or proportion of top SHAP values to plot (e.g., 16 or 0.1 for top 10%). Set to 1.0 (to plot all features or 1 to plot top first feature.
 - *metrics*: scikit-learn metric to use
 
 ## `clf_info` specification
@@ -121,9 +119,7 @@ then an empty dictionary **MUST** be provided as parameter 3.
  "gen_shap": true,
  "nsamples": 100,
  "l1_reg": "aic",
- "plot_shap": true,
  "plot_top_n_shap": 16,
- "confusion_matrix": true,
  "metrics": ["roc_auc_score"]
  }
 ```
@@ -144,11 +140,11 @@ Each model contains:
 - `shap-{timestamp}` dir
     - SHAP values are computed for each prediction in each split's test set
     (e.g., 30 bootstrapping splits with 100 prediction will create (30,100) array). The mean is taken across predictions for each split (e.g., resulting in a (64,30) array for 64 features and 30 bootstrapping samples).
-    - `"confusion_matrix": true` and binary classification: will also create a more accurate display of feature importance obtained by splitting predictions into TP, TN, FP, and FN,
+    - For binary classification, a more accurate display of feature importance obtained by splitting predictions into TP, TN, FP, and FN,
     which in turn can allow for error auditing (i.e., what a model pays attention to when making incorrect/false predictions)
         - `quadrant_indexes.pkl`: The TP, TN, FP, FN indexes are saved in  as a `dict` with one `key` per model (permuted models without SHAP values will be skipped automatically), and each key `values` being a bootstrapping split.
         - `summary_values_shap_{model_name}_{prediction_type}.csv` contains all SHAP values and summary statistics ranked by the mean SHAP value across bootstrapping splits. A sample_n column can be empty or NaN if this split did not have the type of prediction in the filename (e.g., you may not have FNs or FPs in a given split with high performance).
-        - `summary_shap_{model_name}_{plot_top_n_shap}.png` contains SHAP value summary statistics for the top N most important features (defined in `plot_top_n_shap`) for better visualization.
+        - `summary_shap_{model_name}_{plot_top_n_shap}.png` contains SHAP value summary statistics for only the top N most important features for better visualization.
 
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ will want to generate `x_indices` programmatically.
 - *gen_shap*: Boolean indicating whether shap values are generated
 - *nsamples*: Number of samples to use for shap estimation
 - *l1_reg*: Type of regularizer to use for shap estimation
-- *plot_top_n_shap*: Number or proportion of top SHAP values to plot (e.g., 16 or 0.1 for top 10%). Set to 1.0 (to plot all features or 1 to plot top first feature.
+- *plot_top_n_shap*: Number or proportion of top SHAP values to plot (e.g., 16 or 0.1 for top 10%). Set to 1.0 (float) to plot all features or 1 (int) to plot top first feature.
 - *metrics*: scikit-learn metric to use
 
 ## `clf_info` specification

--- a/long-spec.json.sample
+++ b/long-spec.json.sample
@@ -22,8 +22,6 @@
  "gen_shap": true,
  "nsamples": 100,
  "l1_reg": "aic",
- "plot_shap": true,
  "plot_top_n_shap": 16,
- "confusion_matrix": true,
  "metrics": ["roc_auc_score", "accuracy_score"]
  }

--- a/long-spec.json.sample
+++ b/long-spec.json.sample
@@ -19,8 +19,11 @@
     "weights": ["uniform", "distance"]}]]
  ],
  "permute": [true, false],
- "noshap": false,
+ "gen_shap": true,
  "nsamples": 100,
  "l1_reg": "aic",
- "metric": ["roc_auc_score", "accuracy_score"]
+ "plot_shap": true,
+ "plot_top_n_shap": 16,
+ "confusion_matrix": true,
+ "metrics": ["roc_auc_score", "accuracy_score"]
  }

--- a/pydra_ml/classifier.py
+++ b/pydra_ml/classifier.py
@@ -58,7 +58,7 @@ def gen_workflow(inputs, cache_dir=None, cache_locations=None):
             X=wf.readcsv.lzout.X,
             permute=wf.lzin.permute,
             model=wf.fit_clf.lzout.model,
-            noshap=wf.lzin.noshap,
+            gen_shap=wf.lzin.gen_shap,
             nsamples=wf.lzin.nsamples,
             l1_reg=wf.lzin.l1_reg,
         )
@@ -69,6 +69,7 @@ def gen_workflow(inputs, cache_dir=None, cache_locations=None):
             ("output", wf.metric.lzout.output),
             ("score", wf.metric.lzout.score),
             ("shaps", wf.shap.lzout.shaps),
+            ("feature_names", wf.readcsv.lzout.feature_names),
         ]
     )
     return wf
@@ -86,5 +87,14 @@ def run_workflow(wf, plugin, plugin_args):
     timestamp = datetime.datetime.utcnow().isoformat()
     with open(f"results-{timestamp}.pkl", "wb") as fp:
         pk.dump(results, fp)
-    gen_report(results, prefix=wf.name, metrics=wf.inputs.metrics)
+
+    gen_report(
+        results,
+        prefix=wf.name,
+        metrics=wf.inputs.metrics,
+        confusion_matrix=wf.inputs.confusion_matrix,
+        gen_shap=wf.inputs.gen_shap,
+        plot_shap=wf.inputs.plot_shap,
+        plot_top_n_shap=wf.inputs.plot_top_n_shap,
+    )
     return results

--- a/pydra_ml/classifier.py
+++ b/pydra_ml/classifier.py
@@ -92,9 +92,7 @@ def run_workflow(wf, plugin, plugin_args):
         results,
         prefix=wf.name,
         metrics=wf.inputs.metrics,
-        confusion_matrix=wf.inputs.confusion_matrix,
         gen_shap=wf.inputs.gen_shap,
-        plot_shap=wf.inputs.plot_shap,
         plot_top_n_shap=wf.inputs.plot_top_n_shap,
     )
     return results

--- a/pydra_ml/report.py
+++ b/pydra_ml/report.py
@@ -1,10 +1,184 @@
+import warnings
+import datetime
+import os
+import pickle
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
+from sklearn.metrics import accuracy_score
 import seaborn as sns
+import matplotlib.pyplot as plt
 
 
-def gen_report(results, prefix, metrics):
+def save_obj(obj, path):
+    with open(path, "wb") as f:
+        pickle.dump(obj, f, pickle.HIGHEST_PROTOCOL)
+
+
+def plot_summary(
+    summary,
+    output_dir=None,
+    filename="shap_LogisticRegression_all_predictions",
+    plot_top_n_shap=16,
+):
+    plt.clf()
+    plt.figure(figsize=(8, 12))
+    # plot without all bootstrapping values
+    summary = summary[["mean", "std", "min", "max"]]
+    if plot_top_n_shap:
+        summary = summary.iloc[:plot_top_n_shap, :]
+        filename += f"_top_{plot_top_n_shap}"
+    hm = sns.heatmap(
+        summary.round(3), annot=True, xticklabels=True, yticklabels=True, cbar=False
+    )
+    hm.set_xticklabels(summary.columns, rotation=45)
+    # hm.set_yticklabels(summary.index, rotation=0)
+    plt.ylabel("Features")
+    plt.tight_layout()
+    plt.show(block=False)
+    plt.savefig(output_dir + f"summary_{filename}.png", dpi=100)
+    return
+
+
+def shaps_to_summary(
+    shaps_n_splits,
+    feature_names=None,
+    output_dir=None,
+    filename="shap_LogisticRegression_all_predictions",
+    plot_shap=True,
+    plot_top_n_shap=16,
+):
+    shaps_n_splits.columns = [
+        "split_{}".format(n) for n in range(shaps_n_splits.shape[1])
+    ]
+    if feature_names:
+        shaps_n_splits.index = feature_names
+    # else:
+    # 	shaps_n_splits.index = [str(n) for n in shaps_n_splits.index]
+    # add summary stats
+    shaps_n_splits["mean"] = shaps_n_splits.mean(axis=1)
+    shaps_n_splits["std"] = shaps_n_splits.std(axis=1)
+    shaps_n_splits["min"] = shaps_n_splits.min(axis=1)
+    shaps_n_splits["max"] = shaps_n_splits.max(axis=1)
+    shaps_n_splits_sorted = shaps_n_splits.sort_values("mean")[::-1]
+    shaps_n_splits_sorted.to_csv(f"{output_dir}summary_values_{filename}.csv")
+    if plot_shap:
+        plot_summary(
+            shaps_n_splits_sorted,
+            output_dir=output_dir,
+            filename=filename,
+            plot_top_n_shap=plot_top_n_shap,
+        )
+    return
+
+
+def gen_report_shap(
+    results, output_dir="./", confusion_matrix=True, plot_shap=True, plot_top_n_shap=16
+):
+    # Create shap_dir
+    timestamp = datetime.datetime.utcnow().isoformat()
+    shap_dir = output_dir + f"shap-{timestamp}/"
+    os.mkdir(shap_dir)
+
+    feature_names = results[0][1].output.feature_names
+    # save all TP, TN, FP, FN indexes
+    indexes_all = {}
+
+    for model_results in results:
+        model_name = model_results[0].get("ml_wf.clf_info")[1]
+        indexes_all[model_name] = []
+        shaps = model_results[
+            1
+        ].output.shaps  # this is (N, P, F) N splits, P predictions, F feature_names
+        # make sure there are shap values (the
+        if np.array(shaps[0]).size == 0:
+            continue
+
+        y_true_and_preds = model_results[1].output.output
+        n_splits = len(y_true_and_preds)
+
+        shaps_n_splits = {
+            "all": [],
+            "tp": [],
+            "tn": [],
+            "fp": [],
+            "fn": [],
+        }  # this is key with shape (F, N) where F is feature_names, N is mean shap values across splits
+        # Obtain values for each bootstrapping split, then append summary statistics to shaps_n_splits
+        for split_i in range(n_splits):
+            shaps_i = shaps[split_i]  # all shap values for this bootstrapping split
+            y_true = y_true_and_preds[split_i][0]
+            y_pred = y_true_and_preds[split_i][1]
+            split_performance = accuracy_score(y_true, y_pred)
+
+            if confusion_matrix:
+                # split prediction indexes into TP, TN, FP, FN, good for error auditing
+                indexes = {"tp": [], "tn": [], "fp": [], "fn": []}
+                for i in range(len(y_true)):
+                    if y_true[i] == y_pred[i] and y_pred[i] == 1:
+                        indexes["tp"].append(i)
+                    elif y_true[i] == y_pred[i] and y_pred[i] == 0:
+                        indexes["tn"].append(i)
+                    elif y_true[i] != y_pred[i] and y_pred[i] == 1:
+                        indexes["fp"].append(i)
+                    elif y_true[i] != y_pred[i] and y_pred[i] == 0:
+                        indexes["fn"].append(i)
+                indexes_all[model_name].append(indexes)
+                #  For each quadrant, obtain F shap values for P predictions, take the absolute mean weighted by performance across all predictions
+                for quadrant in ["tp", "tn", "fp", "fn"]:
+                    if len(indexes.get(quadrant)) == 0:
+                        warnings.warn(
+                            f"There were no {quadrant.upper()}s, this will output NaNs in the csv and figure for this split column"
+                        )
+                    shaps_i_quadrant = shaps_i[
+                        indexes.get(quadrant)
+                    ]  # shape (P, F) P prediction x F feature_names
+                    abs_weighted_shap_values = (
+                        np.abs(shaps_i_quadrant) * split_performance
+                    )
+                    shaps_n_splits[quadrant].append(
+                        np.mean(abs_weighted_shap_values, axis=0)
+                    )
+            #  obtain F shap values for P predictions, take the absolute mean weighted by performance across all predictions
+            abs_weighted_shap_values = np.abs(shaps_i) * split_performance
+            shaps_n_splits["all"].append(np.mean(abs_weighted_shap_values, axis=0))
+
+        if confusion_matrix:
+            # Build df for summary statistics for each quadrant
+            for quadrant in ["tp", "tn", "fp", "fn"]:
+                shaps_n_splits_quadrant = pd.DataFrame(shaps_n_splits.get(quadrant)).T
+                shaps_to_summary(
+                    shaps_n_splits_quadrant,
+                    feature_names,
+                    output_dir=shap_dir,
+                    filename=f"shap_{model_name}_{quadrant}",
+                    plot_shap=plot_shap,
+                    plot_top_n_shap=plot_top_n_shap,
+                )
+
+        # Single csv for all predictions
+        shaps_n_splits_all = pd.DataFrame(shaps_n_splits.get("all")).T
+        shaps_to_summary(
+            shaps_n_splits_all,
+            feature_names,
+            output_dir=shap_dir,
+            filename=f"shap_{model_name}_all_predictions",
+            plot_shap=plot_shap,
+            plot_top_n_shap=plot_top_n_shap,
+        )
+    save_obj(indexes_all, shap_dir + "indexes_quadrant.pkl")
+    return
+
+
+def gen_report(
+    results,
+    prefix,
+    metrics,
+    gen_shap=True,
+    output_dir="./",
+    confusion_matrix=True,
+    plot_shap=True,
+    plot_top_n_shap=16,
+):
     if len(results) == 0:
         raise ValueError("results is empty")
     df = pd.DataFrame(columns=["metric", "score", "Classifier", "type"])
@@ -45,3 +219,13 @@ def gen_report(results, prefix, metrics):
 
         timestamp = datetime.datetime.utcnow().isoformat()
         plt.savefig(f"test-{name}-{timestamp}.png")
+
+    # create SHAP summary csv and figures
+    if gen_shap:
+        gen_report_shap(
+            results,
+            output_dir=output_dir,
+            confusion_matrix=confusion_matrix,
+            plot_shap=plot_shap,
+            plot_top_n_shap=plot_top_n_shap,
+        )

--- a/pydra_ml/report.py
+++ b/pydra_ml/report.py
@@ -24,14 +24,25 @@ def plot_summary(
     plt.figure(figsize=(8, 12))
     # plot without all bootstrapping values
     summary = summary[["mean", "std", "min", "max"]]
-    if plot_top_n_shap:
+    num_features = len(list(summary.index))
+    if (plot_top_n_shap != 1 and type(plot_top_n_shap) == float) or type(
+        plot_top_n_shap
+    ) == int:
+        # if plot_top_n_shap != 1.0 but includes 1 (int)
+        if plot_top_n_shap <= 0:
+            raise ValueError(
+                "plot_top_n_shap should be a float between 0 and 1.0 or an integer >= 1. You set to zero or negative."
+            )
+        elif plot_top_n_shap < 1:
+            plot_top_n_shap = int(np.round(plot_top_n_shap * num_features))
         summary = summary.iloc[:plot_top_n_shap, :]
         filename += f"_top_{plot_top_n_shap}"
+
     hm = sns.heatmap(
         summary.round(3), annot=True, xticklabels=True, yticklabels=True, cbar=False
     )
     hm.set_xticklabels(summary.columns, rotation=45)
-    # hm.set_yticklabels(summary.index, rotation=0)
+    hm.set_yticklabels(summary.index, rotation=0)
     plt.ylabel("Features")
     plt.tight_layout()
     plt.show(block=False)
@@ -44,7 +55,6 @@ def shaps_to_summary(
     feature_names=None,
     output_dir=None,
     filename="shap_LogisticRegression_all_predictions",
-    plot_shap=True,
     plot_top_n_shap=16,
 ):
     shaps_n_splits.columns = [
@@ -61,19 +71,17 @@ def shaps_to_summary(
     shaps_n_splits["max"] = shaps_n_splits.max(axis=1)
     shaps_n_splits_sorted = shaps_n_splits.sort_values("mean")[::-1]
     shaps_n_splits_sorted.to_csv(f"{output_dir}summary_values_{filename}.csv")
-    if plot_shap:
-        plot_summary(
-            shaps_n_splits_sorted,
-            output_dir=output_dir,
-            filename=filename,
-            plot_top_n_shap=plot_top_n_shap,
-        )
+
+    plot_summary(
+        shaps_n_splits_sorted,
+        output_dir=output_dir,
+        filename=filename,
+        plot_top_n_shap=plot_top_n_shap,
+    )
     return
 
 
-def gen_report_shap(
-    results, output_dir="./", confusion_matrix=True, plot_shap=True, plot_top_n_shap=16
-):
+def gen_report_shap(results, output_dir="./", plot_top_n_shap=16):
     # Create shap_dir
     timestamp = datetime.datetime.utcnow().isoformat()
     shap_dir = output_dir + f"shap-{timestamp}/"
@@ -110,50 +118,45 @@ def gen_report_shap(
             y_pred = y_true_and_preds[split_i][1]
             split_performance = accuracy_score(y_true, y_pred)
 
-            if confusion_matrix:
-                # split prediction indexes into TP, TN, FP, FN, good for error auditing
-                indexes = {"tp": [], "tn": [], "fp": [], "fn": []}
-                for i in range(len(y_true)):
-                    if y_true[i] == y_pred[i] and y_pred[i] == 1:
-                        indexes["tp"].append(i)
-                    elif y_true[i] == y_pred[i] and y_pred[i] == 0:
-                        indexes["tn"].append(i)
-                    elif y_true[i] != y_pred[i] and y_pred[i] == 1:
-                        indexes["fp"].append(i)
-                    elif y_true[i] != y_pred[i] and y_pred[i] == 0:
-                        indexes["fn"].append(i)
-                indexes_all[model_name].append(indexes)
-                #  For each quadrant, obtain F shap values for P predictions, take the absolute mean weighted by performance across all predictions
-                for quadrant in ["tp", "tn", "fp", "fn"]:
-                    if len(indexes.get(quadrant)) == 0:
-                        warnings.warn(
-                            f"There were no {quadrant.upper()}s, this will output NaNs in the csv and figure for this split column"
-                        )
-                    shaps_i_quadrant = shaps_i[
-                        indexes.get(quadrant)
-                    ]  # shape (P, F) P prediction x F feature_names
-                    abs_weighted_shap_values = (
-                        np.abs(shaps_i_quadrant) * split_performance
+            # split prediction indexes into TP, TN, FP, FN, good for error auditing
+            indexes = {"tp": [], "tn": [], "fp": [], "fn": []}
+            for i in range(len(y_true)):
+                if y_true[i] == y_pred[i] and y_pred[i] == 1:
+                    indexes["tp"].append(i)
+                elif y_true[i] == y_pred[i] and y_pred[i] == 0:
+                    indexes["tn"].append(i)
+                elif y_true[i] != y_pred[i] and y_pred[i] == 1:
+                    indexes["fp"].append(i)
+                elif y_true[i] != y_pred[i] and y_pred[i] == 0:
+                    indexes["fn"].append(i)
+            indexes_all[model_name].append(indexes)
+            #  For each quadrant, obtain F shap values for P predictions, take the absolute mean weighted by performance across all predictions
+            for quadrant in ["tp", "tn", "fp", "fn"]:
+                if len(indexes.get(quadrant)) == 0:
+                    warnings.warn(
+                        f"There were no {quadrant.upper()}s, this will output NaNs in the csv and figure for this split column"
                     )
-                    shaps_n_splits[quadrant].append(
-                        np.mean(abs_weighted_shap_values, axis=0)
-                    )
+                shaps_i_quadrant = shaps_i[
+                    indexes.get(quadrant)
+                ]  # shape (P, F) P prediction x F feature_names
+                abs_weighted_shap_values = np.abs(shaps_i_quadrant) * split_performance
+                shaps_n_splits[quadrant].append(
+                    np.mean(abs_weighted_shap_values, axis=0)
+                )
             #  obtain F shap values for P predictions, take the absolute mean weighted by performance across all predictions
             abs_weighted_shap_values = np.abs(shaps_i) * split_performance
             shaps_n_splits["all"].append(np.mean(abs_weighted_shap_values, axis=0))
 
-        if confusion_matrix:
-            # Build df for summary statistics for each quadrant
-            for quadrant in ["tp", "tn", "fp", "fn"]:
-                shaps_n_splits_quadrant = pd.DataFrame(shaps_n_splits.get(quadrant)).T
-                shaps_to_summary(
-                    shaps_n_splits_quadrant,
-                    feature_names,
-                    output_dir=shap_dir,
-                    filename=f"shap_{model_name}_{quadrant}",
-                    plot_shap=plot_shap,
-                    plot_top_n_shap=plot_top_n_shap,
-                )
+        # Build df for summary statistics for each quadrant
+        for quadrant in ["tp", "tn", "fp", "fn"]:
+            shaps_n_splits_quadrant = pd.DataFrame(shaps_n_splits.get(quadrant)).T
+            shaps_to_summary(
+                shaps_n_splits_quadrant,
+                feature_names,
+                output_dir=shap_dir,
+                filename=f"shap_{model_name}_{quadrant}",
+                plot_top_n_shap=plot_top_n_shap,
+            )
 
         # Single csv for all predictions
         shaps_n_splits_all = pd.DataFrame(shaps_n_splits.get("all")).T
@@ -162,7 +165,6 @@ def gen_report_shap(
             feature_names,
             output_dir=shap_dir,
             filename=f"shap_{model_name}_all_predictions",
-            plot_shap=plot_shap,
             plot_top_n_shap=plot_top_n_shap,
         )
     save_obj(indexes_all, shap_dir + "indexes_quadrant.pkl")
@@ -170,14 +172,7 @@ def gen_report_shap(
 
 
 def gen_report(
-    results,
-    prefix,
-    metrics,
-    gen_shap=True,
-    output_dir="./",
-    confusion_matrix=True,
-    plot_shap=True,
-    plot_top_n_shap=16,
+    results, prefix, metrics, gen_shap=True, output_dir="./", plot_top_n_shap=16
 ):
     if len(results) == 0:
         raise ValueError("results is empty")
@@ -222,10 +217,4 @@ def gen_report(
 
     # create SHAP summary csv and figures
     if gen_shap:
-        gen_report_shap(
-            results,
-            output_dir=output_dir,
-            confusion_matrix=confusion_matrix,
-            plot_shap=plot_shap,
-            plot_top_n_shap=plot_top_n_shap,
-        )
+        gen_report_shap(results, output_dir=output_dir, plot_top_n_shap=plot_top_n_shap)

--- a/pydra_ml/tasks.py
+++ b/pydra_ml/tasks.py
@@ -23,7 +23,7 @@ def read_file(filename, x_indices=None, target_vars=None, group="groups"):
     if group in data.keys():
         groups = data[:, [group]]
     else:
-        groups = np.array(range(X.shape[0]))
+        groups = list(range(X.shape[0]))
     feature_names = list(X.columns)
     return X.values, Y.values, groups, feature_names
 

--- a/pydra_ml/tasks.py
+++ b/pydra_ml/tasks.py
@@ -2,10 +2,13 @@
 
 import pydra
 import typing as ty
+import numpy as np
 
 
 @pydra.mark.task
-@pydra.mark.annotate({"return": {"X": ty.Any, "Y": ty.Any, "groups": ty.Any}})
+@pydra.mark.annotate(
+    {"return": {"X": ty.Any, "Y": ty.Any, "groups": ty.Any, "feature_names": ty.Any}}
+)
 def read_file(filename, x_indices=None, target_vars=None, group="groups"):
     import pandas as pd
 
@@ -20,8 +23,9 @@ def read_file(filename, x_indices=None, target_vars=None, group="groups"):
     if group in data.keys():
         groups = data[:, [group]]
     else:
-        groups = list(range(X.shape[0]))
-    return X.values, Y.values, groups
+        groups = np.array(range(X.shape[0]))
+    feature_names = list(X.columns)
+    return X.values, Y.values, groups, feature_names
 
 
 @pydra.mark.task
@@ -77,8 +81,8 @@ def calc_metric(output, metrics):
 
 @pydra.mark.task
 @pydra.mark.annotate({"return": {"shaps": ty.Any}})
-def get_shap(X, permute, model, noshap=False, nsamples="auto", l1_reg="aic"):
-    if permute or noshap:
+def get_shap(X, permute, model, gen_shap=False, nsamples="auto", l1_reg="aic"):
+    if permute or not gen_shap:
         return []
     pipe, train_index, test_index = model
     import shap

--- a/pydra_ml/tests/test_classifier.py
+++ b/pydra_ml/tests/test_classifier.py
@@ -14,9 +14,10 @@ inputs = {
     "test_size": 0.2,
     "clf_info": clfs,
     "permute": [True, False],
-    "noshap": False,
+    "gen_shap": True,
     "nsamples": 5,
     "l1_reg": "aic",
+    "plot_top_n_shap": 16,
     "metrics": ["roc_auc_score", "accuracy_score"],
 }
 

--- a/short-spec.json.sample
+++ b/short-spec.json.sample
@@ -8,9 +8,12 @@
   ["sklearn.neural_network", "MLPClassifier", {"alpha": 1, "max_iter": 1000}],
   ["sklearn.tree", "DecisionTreeClassifier", {"max_depth": 5}]
  ],
- "permute": [true, false],
- "noshap": false,
+ "permute": [false, true],
+ "gen_shap": true,
  "nsamples": 100,
  "l1_reg": "aic",
+ "plot_shap": true,
+ "plot_top_n_shap": 16,
+ "confusion_matrix": true,
  "metrics": ["roc_auc_score", "accuracy_score"]
  }

--- a/short-spec.json.sample
+++ b/short-spec.json.sample
@@ -12,8 +12,6 @@
  "gen_shap": true,
  "nsamples": 100,
  "l1_reg": "aic",
- "plot_shap": true,
- "plot_top_n_shap": 16,
- "confusion_matrix": true,
+ "plot_top_n_shap": 1.0,
  "metrics": ["roc_auc_score", "accuracy_score"]
  }


### PR DESCRIPTION
- added SHAP csv and figure output to gen_report with optional plotting and optional subdividing SHAP values per confusion matrix quadrants (TP, TN, FP, FN) or just plotting for all predictions
- added SHAP specifications in short and long json samples
- changed noshap to gen_shap and resulting logic
- explained results-{timestep}.pkl structure and new SHAP dir  in README