### PR TITLE
Update report.py

### DIFF
--- a/pydra_ml/report.py
+++ b/pydra_ml/report.py
@@ -40,9 +40,8 @@ def plot_summary(summary, output_dir=None, filename="shap_plot", plot_top_n_shap
     hm.set_xticklabels(summary.columns, rotation=45)
     hm.set_yticklabels(summary.index, rotation=0)
     plt.ylabel("Features")
-    plt.tight_layout()
     plt.show(block=False)
-    plt.savefig(output_dir + f"summary_{filename}.png", dpi=100)
+    plt.savefig(output_dir + f"summary_{filename}.png", dpi=100, bbox_inches='tight')
 
 
 def shaps_to_summary(


### PR DESCRIPTION
When feature names are long like the ones from egemaps (e.g., "logRelF0-H1-H2_sma3nz_stddevNorm") the y-axis will not fit and `tight_layout` is not applied. Instead, `bbox_inches='tight'` plots correctly.